### PR TITLE
Adds RecipientInformation data class

### DIFF
--- a/src/main/java/com/trustly/api/SignedAPI.java
+++ b/src/main/java/com/trustly/api/SignedAPI.java
@@ -38,6 +38,7 @@ import org.apache.http.util.EntityUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.trustly.api.commons.Method;
 import com.trustly.api.commons.exceptions.TrustlyConnectionException;
 import com.trustly.api.commons.exceptions.TrustlyDataException;
 import com.trustly.api.commons.exceptions.TrustlySignatureException;
@@ -89,7 +90,13 @@ public class SignedAPI {
      * @return Response generated from the request.
      */
     public Response sendRequest(final Request request) {
-        final Gson gson = new GsonBuilder().serializeNulls().create();
+        final GsonBuilder gsonBuilder = new GsonBuilder();
+
+        if (request.getMethod() == Method.VIEW_AUTOMATIC_SETTLEMENT_DETAILS_CSV) {
+            gsonBuilder.serializeNulls();
+        }
+
+        final Gson gson = gsonBuilder.create();
 
         signatureHandler.insertCredentials(request);
         signatureHandler.signRequest(request);

--- a/src/main/java/com/trustly/api/data/request/requestdata/RecipientInformation.java
+++ b/src/main/java/com/trustly/api/data/request/requestdata/RecipientInformation.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Trustly Group AB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.trustly.api.data.request.requestdata;
+
+import com.google.gson.annotations.SerializedName;
+
+public class RecipientInformation {
+    @SerializedName("Partytype")
+    private String partyType;
+    @SerializedName("Firstname")
+    private String firstName;
+    @SerializedName("Lastname")
+    private String lastName;
+    @SerializedName("CountryCode")
+    private String countryCode;
+    @SerializedName("CustomerID")
+    private String customerId;
+    @SerializedName("Address")
+    private String address;
+    @SerializedName("DateOfBirth")
+    private String dateOfBirth;
+
+    public RecipientInformation(final String partyType, final String firstName, final String lastName, final String countryCode) {
+        this.partyType = partyType;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.countryCode = countryCode;
+    }
+
+    public RecipientInformation setCustomerId(final String customerId) {
+        this.customerId = customerId;
+        return this;
+    }
+
+    public RecipientInformation setAddress(final String address) {
+        this.address = address;
+        return this;
+    }
+
+    public RecipientInformation setDateOfBirth(final String dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+        return this;
+    }
+}

--- a/src/main/java/com/trustly/api/requestbuilders/Deposit.java
+++ b/src/main/java/com/trustly/api/requestbuilders/Deposit.java
@@ -32,6 +32,7 @@ import com.trustly.api.commons.Method;
 import com.trustly.api.data.request.Request;
 import com.trustly.api.data.request.RequestParameters;
 import com.trustly.api.data.request.requestdata.DepositData;
+import com.trustly.api.data.request.requestdata.RecipientInformation;
 import com.trustly.api.security.SignatureHandler;
 
 /**
@@ -134,6 +135,11 @@ public class Deposit {
 
         public Build nationalIdentificationNumber(final String nin) {
             attributes.put("NationalIdentificationNumber", nin);
+            return this;
+        }
+
+        public Build recipientInformation(final RecipientInformation recipientInformation) {
+            attributes.put("RecipientInformation", recipientInformation);
             return this;
         }
 


### PR DESCRIPTION
Money remittance merchants must now supply
information on who is the final receiver of
the transaction.

This commit adds a data class that can be
created and passed in to the Deposit builder
allowing merchants to supply this information.