### PR TITLE
RecipientInformation: Add toString method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,13 @@
             <version>1.57</version>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 

--- a/src/main/java/com/trustly/api/data/request/requestdata/RecipientInformation.java
+++ b/src/main/java/com/trustly/api/data/request/requestdata/RecipientInformation.java
@@ -63,4 +63,28 @@ public class RecipientInformation {
         this.dateOfBirth = dateOfBirth;
         return this;
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder stringBuilder = new StringBuilder();
+
+        stringBuilder.append("Partytype").append(partyType);
+        stringBuilder.append("Firstname").append(firstName);
+        stringBuilder.append("Lastname").append(lastName);
+        stringBuilder.append("CountryCode").append(countryCode);
+
+        if (customerId != null) {
+            stringBuilder.append("CustomerID").append(customerId);
+        }
+
+        if (address != null) {
+            stringBuilder.append("Address").append(address);
+        }
+
+        if (dateOfBirth != null) {
+            stringBuilder.append("DateOfBirth").append(dateOfBirth);
+        }
+
+        return stringBuilder.toString();
+    }
 }

--- a/src/main/java/com/trustly/api/data/request/requestdata/RecipientInformation.java
+++ b/src/main/java/com/trustly/api/data/request/requestdata/RecipientInformation.java
@@ -24,6 +24,10 @@
 
 package com.trustly.api.data.request.requestdata;
 
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
 import com.google.gson.annotations.SerializedName;
 
 public class RecipientInformation {
@@ -64,27 +68,37 @@ public class RecipientInformation {
         return this;
     }
 
+    /**
+     * Method for returning a String representation of the
+     * RecipientInformation object. Used for serialization.
+     * <p>
+     * Uses a TreeMap for automatically sorting the object's
+     * field values in an alphabetical order, which is required
+     * for generating a valid signature from the serialized string.
+     */
     @Override
     public String toString() {
-        final StringBuilder stringBuilder = new StringBuilder();
+        final Map<String, String> attributes = new TreeMap<>();
 
-        stringBuilder.append("Partytype").append(partyType);
-        stringBuilder.append("Firstname").append(firstName);
-        stringBuilder.append("Lastname").append(lastName);
-        stringBuilder.append("CountryCode").append(countryCode);
+        attributes.put("Partytype", partyType);
+        attributes.put("Firstname", firstName);
+        attributes.put("Lastname", lastName);
+        attributes.put("CountryCode", countryCode);
 
         if (customerId != null) {
-            stringBuilder.append("CustomerID").append(customerId);
+            attributes.put("CustomerID", customerId);
         }
 
         if (address != null) {
-            stringBuilder.append("Address").append(address);
+            attributes.put("Address", address);
         }
 
         if (dateOfBirth != null) {
-            stringBuilder.append("DateOfBirth").append(dateOfBirth);
+            attributes.put("DateOfBirth", dateOfBirth);
         }
 
-        return stringBuilder.toString();
+        return attributes.entrySet().stream()
+                .map(entry -> entry.getKey() + entry.getValue())
+                .collect(Collectors.joining());
     }
 }

--- a/src/test/java/com/trustly/api/data/request/requestdata/RecipientInformationTest.java
+++ b/src/test/java/com/trustly/api/data/request/requestdata/RecipientInformationTest.java
@@ -1,0 +1,45 @@
+package com.trustly.api.data.request.requestdata;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RecipientInformationTest {
+
+    private RecipientInformation recipientInformation;
+
+    @Before
+    public void setUp() {
+        recipientInformation = new RecipientInformation("PERSON", "Tester", "McTester", "TE");
+    }
+
+    @Test
+    public void toStringPrintsMandatoryFieldsInCorrectOrder() {
+        final String toStringResult = recipientInformation.toString();
+        final String expectedResult = "CountryCodeTEFirstnameTesterLastnameMcTesterPartytypePERSON";
+
+        Assert.assertEquals(expectedResult, toStringResult);
+    }
+
+    @Test
+    public void toStringPrintsMandatoryAndOptionalFieldsInCorrectOrder() {
+        recipientInformation.setAddress("TesterStreet 14, 12345, TesterCity")
+                            .setCustomerId("123456789")
+                            .setDateOfBirth("1987-07-27");
+
+        final String toStringResult = recipientInformation.toString();
+        final String expectedResult = "AddressTesterStreet 14, 12345, TesterCityCountryCodeTECustomerID123456789DateOfBirth1987-07-27FirstnameTesterLastnameMcTesterPartytypePERSON";
+
+        Assert.assertEquals(expectedResult, toStringResult);
+    }
+
+    @Test
+    public void toStringPrintsMandatoryFieldsWhenNull() {
+        recipientInformation = new RecipientInformation(null, null, null, null);
+
+        final String toStringResult = recipientInformation.toString();
+        final String expectedResult = "CountryCodenullFirstnamenullLastnamenullPartytypenull";
+
+        Assert.assertEquals(expectedResult, toStringResult);
+    }
+}


### PR DESCRIPTION
When creating the signature from a Deposit object
containing a RecipientInformation object, the plain
string of the signature contained not a serialized
representation of the RI object, but instead its
object address given by Object.toString.

This commit overrides the default toString in
order to make a serializable representation of
the RecipientInformation object.