### PR TITLE
Disregard null values for AttributeData

### DIFF
--- a/src/main/java/com/trustly/api/security/SignatureHandler.java
+++ b/src/main/java/com/trustly/api/security/SignatureHandler.java
@@ -152,6 +152,10 @@ public class SignatureHandler {
             final StringBuilder builder = new StringBuilder();
             for (final Field field : fields) {
 
+                if (field.get(data) == null && data instanceof AttributeData) {
+                    continue;
+                }
+
                 final String jsonFieldName;
                 if (field.isAnnotationPresent(SerializedName.class)) {
                     jsonFieldName = field.getAnnotation(SerializedName.class).value();


### PR DESCRIPTION
When generating the request signature, we do not
wish to include optional values that are set to
null as they can be omitted.

An oversight led to us still including fields with
null values for the RecipientInformation class.

With this commit, we now ignore fields with null
values for instances of Attribute data as well.