### PR TITLE
Upgrade servlet-api from javax to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/com/trustly/api/client/TrustlyApiClientExtensions.java
+++ b/src/main/java/com/trustly/api/client/TrustlyApiClientExtensions.java
@@ -13,8 +13,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class TrustlyApiClientExtensions {
 


### PR DESCRIPTION
`servlet-api` artifact was moved from javax to jakarta group id in 2019. This PR proposes to use newer version of `servlet-api` artifact.

I tried to use this client as a artifact in my Spring Boot project. [trustly-client-java](https://github.com/trustly/trustly-client-java) uses `javax.servlet-api` and Spring Boot uses `jakarta.servlet-api`. In order to use latest version of **HttpServletRequest** and **HttpServletResponse** classes and resolve the package conflict, I created this PR.

[javax.servlet-api mvn repository link](https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api)
[jakarta.servlet-api mvn repository link](https://mvnrepository.com/artifact/jakarta.servlet/jakarta.servlet-api)

