### PR TITLE
Update models + Handle verify signature for empty/not sent fields

### DIFF
--- a/src/main/java/com/trustly/api/client/DefaultJsonRpcSigner.java
+++ b/src/main/java/com/trustly/api/client/DefaultJsonRpcSigner.java
@@ -95,13 +95,13 @@ public class DefaultJsonRpcSigner implements JsonRpcSigner {
   }
 
   @Override
-  public <D extends IRequestParamsData, P extends IRequestParams<D>> void verify(IRequest<P> request) throws TrustlySignatureException {
+  public <D extends IRequestParamsData, P extends IRequestParams<D>> void verify(IRequest<P> request, JsonNode dataNode) throws TrustlySignatureException {
 
     String uuid = (request.getParams() == null) ? null : request.getParams().getUuid();
     String signature = (request.getParams() == null) ? null : request.getParams().getSignature();
     D data = (request.getParams() == null) ? null : request.getParams().getData();
 
-    this.verify(request.getMethod(), uuid, signature, data, null);
+    this.verify(request.getMethod(), uuid, signature, data, dataNode);
   }
 
   @Override

--- a/src/main/java/com/trustly/api/client/JsonRpcSigner.java
+++ b/src/main/java/com/trustly/api/client/JsonRpcSigner.java
@@ -15,7 +15,7 @@ public interface JsonRpcSigner {
 
   <T extends IResponseResultData> JsonRpcResponse<T> sign(JsonRpcResponse<T> response);
 
-  <D extends IRequestParamsData, P extends IRequestParams<D>> void verify(IRequest<P> request) throws TrustlySignatureException;
+  <D extends IRequestParamsData, P extends IRequestParams<D>> void verify(IRequest<P> request, JsonNode dataNode) throws TrustlySignatureException;
 
   <T extends IResponseResultData> void verify(JsonRpcResponse<T> response, JsonNode nodeResponse) throws TrustlySignatureException;
 }

--- a/src/main/java/com/trustly/api/client/NotificationArgs.java
+++ b/src/main/java/com/trustly/api/client/NotificationArgs.java
@@ -26,7 +26,10 @@ public class NotificationArgs<D extends IRequestParamsData> {
   @Valid
   private final D data;
 
+  @Getter
   private final String method;
+
+  @Getter
   private final String uuid;
 
   private final NotificationOkHandler onOK;

--- a/src/main/java/com/trustly/api/domain/common/AbstractAccountDataAttributes.java
+++ b/src/main/java/com/trustly/api/domain/common/AbstractAccountDataAttributes.java
@@ -138,9 +138,21 @@ public class AbstractAccountDataAttributes extends AbstractRequestParamsDataAttr
   String unchangeableNationalIdentificationNumber;
 
   /**
+   * @deprecated (see ReturnToAppURL)
    * If you are using Trustly from within your native iOS app, this attribute should be sent so that we can redirect the users back to your
    * app in case an external app is used for authentication (for example Mobile Bank ID in Sweden).
    */
+  @Deprecated
   @JsonProperty("URLScheme")
   String urlScheme;
+
+  /**
+   * When rendering the Trustly Checkout in a native app you are required to pass your application’s url as an attribute to the order
+   * initiation request. By doing so, Trustly can redirect users back to your app after using external identification apps such as
+   * Mobile BankID: Please visit this link for more info. It must not be included for transactions that are not originating from an app.
+   * NOTE! This value is only used for redirecting users back to the native app within the flows.
+   * See also SuccessURL and FailURL descriptions.
+   */
+  @JsonProperty("ReturnToAppURL")
+  String returnToAppURL;
 }

--- a/src/main/java/com/trustly/api/domain/notifications/CancelNotificationData.java
+++ b/src/main/java/com/trustly/api/domain/notifications/CancelNotificationData.java
@@ -30,4 +30,10 @@ public class CancelNotificationData extends AbstractFromTrustlyRequestData<Empty
 
   @JsonProperty("timestamp")
   String timestamp;
+
+  @JsonProperty("lastorderstep")
+  String lastOrderStep;
+
+  @JsonProperty("orderstatuses")
+  String orderStatuses;
 }

--- a/src/test/java/com/trustly/api/NoOpJsonRpcSigner.java
+++ b/src/test/java/com/trustly/api/NoOpJsonRpcSigner.java
@@ -22,7 +22,7 @@ class NoOpJsonRpcSigner implements JsonRpcSigner {
   }
 
   @Override
-  public <D extends IRequestParamsData, P extends IRequestParams<D>> void verify(IRequest<P> request) {
+  public <D extends IRequestParamsData, P extends IRequestParams<D>> void verify(IRequest<P> request, JsonNode dataNode) {
 
   }
 


### PR DESCRIPTION
The reason for this PR is to fix the cancel notification throwing exception due to testing servers is sending two new properties.
This also addresses the 3 issues I've created
https://github.com/trustly/trustly-client-java/issues/33
https://github.com/trustly/trustly-client-java/issues/34
https://github.com/trustly/trustly-client-java/issues/35 

- Add `lastorderstep` and `orderstatuses` to `CancelNotificationData`
- Add `ReturnToAppURL` to `AbstractAccountDataAttributes`
- Deprecate `urlSheme` in `AbstractAccountDataAttributes`
- Add `@Getter` to `method` and `uuid` for easier access to them
- Update `JsonRpcSigner.verify` to take a `JsonNode` dataNode for verifying signature to handle null/not send values if Trustly sever does not send those values

I was also thinking of disabling `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` on the object mapper in `TrustlyApiClient` so the parsing don't crash if Trustly server sends a new value. I left it out here.

I have validated locally that the cancel notification now works and don't throw any exception and the verifying of signature also work.